### PR TITLE
No upper cap on typing-extensions version (fixes issue #5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ files = [ "dataclass_utils/VERSION.py",]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-typing-extensions = "^3.10"
+typing-extensions = ">=3.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
When using the `^3.10` syntax, poetry also adds an upper cap (`<4.0`) on the version of `typing-extensions`, which is problematic as explained in issue #5. Therefore this PR changes the `^3.10` to `>=3.10`, avoiding the problematic upper cap.